### PR TITLE
fixed page refresh on search submit

### DIFF
--- a/src/client/app/SearchBar.jsx
+++ b/src/client/app/SearchBar.jsx
@@ -15,7 +15,8 @@ class SearchBar extends Component{
     })
   }
 
-  searchProducts() {
+  searchProducts(e) {
+    e.preventDefault();
     var handleSearch = this.props.handleSearch
     var query = this.state.query
     axios.get('http://localhost:3000/search', {
@@ -23,12 +24,12 @@ class SearchBar extends Component{
         query: query
       }
     })
-    .then(function(response) {
-    handleSearch(response.data);
+    .then((res) => {
+    handleSearch(res.data);
     })
-    .catch(function(error) {
-      console.log(error)
-    })
+    .catch((err) => {
+      console.log(err);
+    });
   }
 
   onClick() {


### PR DESCRIPTION
Looks like the page was refreshing whenever a search query was submitted. Not sure why this started acting up just now, but added e.preventDefault(); to stop that. Also refactored get request to ES6 for uniformity.