### PR TITLE
fixed popular items and product details

### DIFF
--- a/server/request-handler.js
+++ b/server/request-handler.js
@@ -96,6 +96,7 @@ exports.lookUp = (req, res) => {
       details.name = item.name;
       details.desc = item.longDescription;
       details.imageUrl = item.largeImage;
+      details.thumbnailImage = item.thumbnailImage;
       details.price = item.salePrice;
       res.json(details);
     })

--- a/src/client/app/Item.jsx
+++ b/src/client/app/Item.jsx
@@ -13,12 +13,17 @@ class Item extends Component {
   }
 
   handleAddItem() {
-    let item = this.props.item
+    let item = {};
+    item.name = this.props.item.name;
+    item.image = this.props.item.thumbnailImage;
+    item.itemId = this.props.item.itemId;
+    item.url = this.props.item.productUrl;
+    item.price = this.props.item.salePrice;
+
     this.props.addToList(item);
   }
 
-  handleItemClick(e) {
-    e.preventDefault();
+  handleItemClick() {
     this.setState({
       showDetails: !this.state.showDetails
     });
@@ -43,7 +48,7 @@ class Item extends Component {
             }
           }}
         >
-          <ProductDetails itemId={item.itemId} itemUrl={item.productUrl}/>
+          <ProductDetails itemId={item.itemId} itemUrl={item.productUrl} addToList={this.props.addToList}/>
         </Modal>
         <div className="item-title">
           <a className="btn-link btn-block" onClick={this.handleItemClick}><strong>{item.name.substring(0, 40)}</strong></a>

--- a/src/client/app/ProductDetails.jsx
+++ b/src/client/app/ProductDetails.jsx
@@ -33,7 +33,14 @@ class ProductDetails extends Component {
   }
 
   handleAddToList() {
-    // TODO: add this item to the current wishlist
+    let item = {};
+    item.name = this.state.details.name;
+    item.image = this.state.details.thumbnailImage;
+    item.itemId = this.props.itemId;
+    item.url = this.props.itemUrl;
+    item.price = this.state.details.price;
+
+    this.props.addToList(item);
   }
 
   render() {

--- a/src/client/app/SearchResultsEntry.jsx
+++ b/src/client/app/SearchResultsEntry.jsx
@@ -46,7 +46,7 @@ class SearchResultsEntry extends Component {
             }
           }}
         >
-          <ProductDetails itemId={item.itemId} itemUrl={item.url}/>
+          <ProductDetails itemId={item.itemId} itemUrl={item.url} addToList={this.props.addToList}/>
         </Modal>
         <div className="col-sm-3">
           <a className="btn btn-link" onClick={this.handleItemClick.bind(this)}><strong>{item.name.substring(0, 40)}</strong></a>


### PR DESCRIPTION
The "Add to List" button for popular items and product details should properly add item information to the shopping list now.

With this PR I am also testing what happens if I submit a new PR while I have a previous one open. There is a slight chance of a small merge conflict in Item.jsx.