### PR TITLE
fixed searchbar overlap

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -46,3 +46,7 @@
 .list-tools {
   margin-bottom: 20px;
 }
+
+.under {
+  z-index: -1;
+}

--- a/src/client/app/SearchBar.jsx
+++ b/src/client/app/SearchBar.jsx
@@ -41,10 +41,10 @@ class SearchBar extends Component{
   render() {
     return (
       <form onSubmit={this.searchProducts} className="search">
-        <div className="input-group">
-          <input id={this.state.query} className="form-control" onChange={this.onSearch} type="text"/>
-          <span className="input-group-btn">
-            <button type="submit" id={this.state.query} onClick={this.searchProducts} className="searchBtn btn btn-primary">
+        <div className="input-group under">
+          <input id={this.state.query} className="form-control under" onChange={this.onSearch} type="text"/>
+          <span className="input-group-btn under">
+            <button type="submit" id={this.state.query} onClick={this.searchProducts} className="searchBtn btn btn-primary under">
               Search
             </button>
           </span>


### PR DESCRIPTION
search bar and search button now renders below the overlay when modal is open.
![screen shot 2017-10-06 at 9 37 59 am](https://user-images.githubusercontent.com/29634643/31288527-246a7f2a-aa7a-11e7-9409-2ab6752f658b.png)
